### PR TITLE
Implement branch argument for start-task

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,14 @@ This process will:
 ## Using the Workflow
 
 1.  **Starting a Task (Developer):**
-    When a developer needs to assign a task to the agent, they run the `start-task` command within their repository:
+    When a developer needs to assign a task to the agent, they run the `start-task` command with the desired branch name:
+
+    ```bash
+    start-task <branch-name>
+    ```
 
     This script will:
-    -   Prompt the developer to enter a branch name and the task description in an editor.
+    -   Prompt the developer to enter the task description in an editor.
     -   Create a new Git branch based on the provided name.
     -   Commit the task description to a file within a `.agents/tasks/` directory on the new branch.
     -   Push the branch to the default remote.

--- a/bin/lib/vcs_repo.rb
+++ b/bin/lib/vcs_repo.rb
@@ -28,22 +28,23 @@ class VCSRepo
   end
 
   def start_branch(branch_name)
+    success = false
     Dir.chdir(@root) do
       case @vcs_type
       when :git
-        system("git checkout -b #{branch_name}")
+        success = system("git checkout -b #{branch_name}")
       when :hg
-        system("hg branch #{branch_name}")
+        success = system("hg branch #{branch_name}")
       when :bzr
-        system("bzr switch -b #{branch_name}")
+        success = system("bzr switch -b #{branch_name}")
       when :fossil
-        system("fossil branch new #{branch_name} trunk")
-        system("fossil update #{branch_name}")
+        success = system("fossil branch new #{branch_name} trunk") &&
+                  system("fossil update #{branch_name}")
       else
-        puts "Error: Unknown VCS type (#{@vcs_type}) to start branch"
-        exit 1
+        raise "Error: Unknown VCS type (#{@vcs_type}) to start branch"
       end
     end
+    raise "Error: Failed to create branch '#{branch_name}'" unless success
   end
 
   def commit_file(file_path, message)

--- a/bin/start-task
+++ b/bin/start-task
@@ -11,33 +11,20 @@ def find_default_editor
   editors.find { |e| system("command -v #{e} > /dev/null 2>&1") } || 'nano'
 end
 
-# Create a temporary file with "branch:" as its contents
-tempfile = Tempfile.new(['branch', '.txt'])
-tempfile.write("branch:")
-tempfile.flush
+
+branch_name = ARGV.shift
+if branch_name.nil? || branch_name.strip.empty?
+  abort("Usage: #{File.basename(__FILE__)} <branch-name>")
+end
+
+# Create a temporary file for the task description
+tempfile = Tempfile.new(['task', '.txt'])
 
 editor = find_default_editor
 system("#{editor} #{tempfile.path}") || abort("Error: Failed to open the editor.")
 tempfile.close
 
-all_lines = File.readlines(tempfile.path, chomp: true)
-branch_line = all_lines.first || ""
-
-# Strip "branch: " prefix if present, otherwise use the entire line
-branch_name = if branch_line.start_with?("branch: ")
-  branch_line.sub(/^branch: /, '')
-else
-  branch_line
-end
-
-# Replace all continuous characters not allowed in git branch names with a single "-"
-sanitized_branch = branch_name.gsub(%r{[^A-Za-z0-9/_\-.]+}, '-')
-sanitized_branch.gsub!(%r{(^[-.]+|[-.]+$)}, '') # trim leading/trailing - or .
-sanitized_branch.gsub!(%r{/{2,}}, '/')          # collapse multiple slashes
-sanitized_branch.gsub!(%r{\.+}, '.')            # collapse multiple dots
-
-# The rest of the file is task content
-task_content = all_lines.drop(1).join("\n")
+task_content = File.read(tempfile.path)
 
 begin
   repo = VCSRepo.new
@@ -51,7 +38,7 @@ root = repo.root
 orig_branch = repo.current_branch
 
 # Start a new branch
-repo.start_branch(sanitized_branch)
+repo.start_branch(branch_name)
 
 # Create the agents task file path
 now = Time.now.utc
@@ -60,11 +47,11 @@ month = "%02d" % now.month
 day = "%02d" % now.day
 hour = "%02d" % now.hour
 min = "%02d" % now.min
-filename = "#{day}-#{hour}#{min}-#{sanitized_branch}"
+filename = "#{day}-#{hour}#{min}-#{branch_name}"
 tasks_dir = File.join(repo.root, ".agents", "tasks", year.to_s, month)
 FileUtils.mkdir_p(tasks_dir)
 task_file = File.join(tasks_dir, filename)
-commit_msg = "start-agent-task: #{sanitized_branch}"
+commit_msg = "start-agent-task: #{branch_name}"
 
 # Write the task content
 File.write(task_file, task_content)
@@ -77,7 +64,7 @@ print "Push to default remote? [Y/n]: "
 answer = STDIN.gets.strip
 answer = "y" if answer.empty?
 if answer.downcase.start_with?("y")
-  repo.push_current_branch(sanitized_branch)
+  repo.push_current_branch(branch_name)
 end
 
 # Return to original branch

--- a/test/test_start_task.rb
+++ b/test/test_start_task.rb
@@ -11,11 +11,6 @@ def git(repo, *args)
   system({'GIT_CONFIG_NOSYSTEM'=>'1'}, *cmd, chdir: repo, out: File::NULL, err: File::NULL)
 end
 
-def git_capture(repo, *args)
-  cmd = ['git', *args]
-  `#{cmd.shelljoin}`
-end
-
 def setup_git_repo
   remote = Dir.mktmpdir('remote')
   system('git', 'init', '--bare', remote, out: File::NULL)
@@ -31,11 +26,12 @@ def setup_git_repo
 end
 
 # run start-task with given editor content
-# lines is array of lines to write to temp file
+# branch: branch name to pass as argument
+# lines: array of lines to write to temp file
 # editor_exit: exit code for editor
 # input: text to send to start-task via stdin
 
-def run_start_task(repo, lines: [], editor_exit: 0, input: "y\n")
+def run_start_task(repo, branch:, lines: [], editor_exit: 0, input: "y\n")
   dir = Dir.mktmpdir('editor')
   script = File.join(dir, 'fake_editor.sh')
   File.write(script, <<~SH)
@@ -49,7 +45,7 @@ def run_start_task(repo, lines: [], editor_exit: 0, input: "y\n")
   output = nil
   status = nil
   Dir.chdir(repo) do
-    IO.popen({'EDITOR'=>script}, [START_TASK], 'r+') do |io|
+    IO.popen({'EDITOR'=>script}, [START_TASK, branch], 'r+') do |io|
       io.write input
       io.close_write
       output = io.read
@@ -63,7 +59,7 @@ end
 class StartTaskGitTest < Minitest::Test
   def test_clean_repo
     repo, remote = setup_git_repo
-    status, _ = run_start_task(repo, lines: ['branch: feature', 'task'])
+    status, _ = run_start_task(repo, branch: 'feature', lines: ['task'])
     assert_equal 0, status.exitstatus
     # start-task should switch back to main after creating the feature branch
     assert_equal 'main', `git -C #{repo} rev-parse --abbrev-ref HEAD`.strip
@@ -85,7 +81,7 @@ class StartTaskGitTest < Minitest::Test
     repo, remote = setup_git_repo
     File.write(File.join(repo, 'foo.txt'), 'foo')
     git(repo, 'add', 'foo.txt')
-    status, _ = run_start_task(repo, lines: ['branch: s1', 'task'])
+    status, _ = run_start_task(repo, branch: 's1', lines: ['task'])
     assert_equal 0, status.exitstatus
     # ensure staged changes are restored and nothing else changed
     assert_equal '', `git -C #{repo} status --porcelain`
@@ -98,7 +94,7 @@ class StartTaskGitTest < Minitest::Test
     repo, remote = setup_git_repo
     File.write(File.join(repo, 'bar.txt'), 'bar')
     status_before = `git -C #{repo} status --porcelain`
-    status, _ = run_start_task(repo, lines: ['branch: s2', 'task'])
+    status, _ = run_start_task(repo, branch: 's2', lines: ['task'])
     assert_equal 0, status.exitstatus
     # unstaged modifications should remain exactly as they were
     assert_equal status_before, `git -C #{repo} status --porcelain`
@@ -109,7 +105,7 @@ class StartTaskGitTest < Minitest::Test
 
   def test_editor_failure
     repo, remote = setup_git_repo
-    status, _ = run_start_task(repo, lines: ['branch: bad'], editor_exit: 1)
+    status, _ = run_start_task(repo, branch: 'bad', lines: [], editor_exit: 1)
     assert status.exitstatus != 0
     # when the editor fails, no branch should have been created
     refute `git -C #{repo} branch --list bad`.strip.size > 0
@@ -120,22 +116,23 @@ class StartTaskGitTest < Minitest::Test
 
   def test_empty_file
     repo, remote = setup_git_repo
-    status, _ = run_start_task(repo, lines: [])
+    status, _ = run_start_task(repo, branch: 'empty', lines: [])
     assert_equal 0, status.exitstatus
     branches = `git -C #{repo} branch --list`.split("\n").map(&:strip)
-    # saving an empty task file should leave only the main branch
-    assert_equal ['* main'], branches
+    # an empty task file should still result in the new branch being created
+    assert_includes branches, 'empty'
+    assert_includes branches, '* main'
   ensure
     FileUtils.remove_entry(repo)
     FileUtils.remove_entry(remote)
   end
 
-  def test_branch_sanitization
+  def test_invalid_branch
     repo, remote = setup_git_repo
-    status, _ = run_start_task(repo, lines: ['branch: inv@lid name', 'task'])
-    assert_equal 0, status.exitstatus
-    # the branch name should be sanitized of invalid characters
-    assert `git -C #{repo} branch --list inv-lid-name`.strip.size > 0
+    status, _ = run_start_task(repo, branch: 'inv@lid name', lines: ['task'])
+    assert status.exitstatus != 0
+    # no branch should be created when the branch name is invalid
+    refute `git -C #{repo} branch --list 'inv@lid name'`.strip.size > 0
   ensure
     FileUtils.remove_entry(repo)
     FileUtils.remove_entry(remote)


### PR DESCRIPTION
## Summary
- refactor `start-task` to accept the branch name as a command argument
- validate branch creation and stop sanitising names
- adjust VCS helper to raise on branch creation failure
- update README usage instructions
- update test suite for new CLI behaviour

## Testing
- `just test`