### PR TITLE
Implement early branch validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ This process will:
     ```
 
     This script will:
+    -   Create the branch first and abort early with the VCS error message if
+        the name is invalid.
     -   Prompt the developer to enter the task description in an editor.
-    -   Create a new Git branch based on the provided name.
     -   Commit the task description to a file within a `.agents/tasks/` directory on the new branch.
     -   Push the branch to the default remote.
 

--- a/bin/start-task
+++ b/bin/start-task
@@ -17,28 +17,37 @@ if branch_name.nil? || branch_name.strip.empty?
   abort("Usage: #{File.basename(__FILE__)} <branch-name>")
 end
 
-# Create a temporary file for the task description
-tempfile = Tempfile.new(['task', '.txt'])
-
-editor = find_default_editor
-system("#{editor} #{tempfile.path}") || abort("Error: Failed to open the editor.")
-tempfile.close
-
-task_content = File.read(tempfile.path)
-
+# Initialize repository and create branch first
 begin
   repo = VCSRepo.new
 rescue StandardError => e
   puts e.message
   exit 1
 end
-root = repo.root
 
-# Save current branch for later
 orig_branch = repo.current_branch
 
-# Start a new branch
-repo.start_branch(branch_name)
+begin
+  repo.start_branch(branch_name)
+rescue StandardError => e
+  puts e.message
+  exit 1
+end
+
+# Create a temporary file for the task description
+tempfile = Tempfile.new(['task', '.txt'])
+
+editor = find_default_editor
+unless system("#{editor} #{tempfile.path}")
+  repo.checkout_branch(orig_branch) if orig_branch
+  if repo.vcs_type == :git
+    system('git', 'branch', '-D', branch_name, chdir: repo.root, out: File::NULL, err: File::NULL)
+  end
+  abort("Error: Failed to open the editor.")
+end
+tempfile.close
+
+task_content = File.read(tempfile.path)
 
 # Create the agents task file path
 now = Time.now.utc

--- a/test/test_start_task.rb
+++ b/test/test_start_task.rb
@@ -34,8 +34,10 @@ end
 def run_start_task(repo, branch:, lines: [], editor_exit: 0, input: "y\n")
   dir = Dir.mktmpdir('editor')
   script = File.join(dir, 'fake_editor.sh')
+  marker = File.join(dir, 'called')
   File.write(script, <<~SH)
     #!/bin/sh
+    echo yes > #{marker}
     cat <<'EOS' > "$1"
     #{lines.join("\n")}
     EOS
@@ -52,14 +54,15 @@ def run_start_task(repo, branch:, lines: [], editor_exit: 0, input: "y\n")
     end
     status = $?
   end
+  executed = File.exist?(marker)
   FileUtils.remove_entry(dir)
-  [status, output]
+  [status, output, executed]
 end
 
 class StartTaskGitTest < Minitest::Test
   def test_clean_repo
     repo, remote = setup_git_repo
-    status, _ = run_start_task(repo, branch: 'feature', lines: ['task'])
+    status, _, _ = run_start_task(repo, branch: 'feature', lines: ['task'])
     assert_equal 0, status.exitstatus
     # start-task should switch back to main after creating the feature branch
     assert_equal 'main', `git -C #{repo} rev-parse --abbrev-ref HEAD`.strip
@@ -81,7 +84,7 @@ class StartTaskGitTest < Minitest::Test
     repo, remote = setup_git_repo
     File.write(File.join(repo, 'foo.txt'), 'foo')
     git(repo, 'add', 'foo.txt')
-    status, _ = run_start_task(repo, branch: 's1', lines: ['task'])
+    status, _, _ = run_start_task(repo, branch: 's1', lines: ['task'])
     assert_equal 0, status.exitstatus
     # ensure staged changes are restored and nothing else changed
     assert_equal '', `git -C #{repo} status --porcelain`
@@ -94,7 +97,7 @@ class StartTaskGitTest < Minitest::Test
     repo, remote = setup_git_repo
     File.write(File.join(repo, 'bar.txt'), 'bar')
     status_before = `git -C #{repo} status --porcelain`
-    status, _ = run_start_task(repo, branch: 's2', lines: ['task'])
+    status, _, _ = run_start_task(repo, branch: 's2', lines: ['task'])
     assert_equal 0, status.exitstatus
     # unstaged modifications should remain exactly as they were
     assert_equal status_before, `git -C #{repo} status --porcelain`
@@ -105,7 +108,7 @@ class StartTaskGitTest < Minitest::Test
 
   def test_editor_failure
     repo, remote = setup_git_repo
-    status, _ = run_start_task(repo, branch: 'bad', lines: [], editor_exit: 1)
+    status, _, _ = run_start_task(repo, branch: 'bad', lines: [], editor_exit: 1)
     assert status.exitstatus != 0
     # when the editor fails, no branch should have been created
     refute `git -C #{repo} branch --list bad`.strip.size > 0
@@ -116,7 +119,7 @@ class StartTaskGitTest < Minitest::Test
 
   def test_empty_file
     repo, remote = setup_git_repo
-    status, _ = run_start_task(repo, branch: 'empty', lines: [])
+    status, _, _ = run_start_task(repo, branch: 'empty', lines: [])
     assert_equal 0, status.exitstatus
     branches = `git -C #{repo} branch --list`.split("\n").map(&:strip)
     # an empty task file should still result in the new branch being created
@@ -129,7 +132,8 @@ class StartTaskGitTest < Minitest::Test
 
   def test_invalid_branch
     repo, remote = setup_git_repo
-    status, _ = run_start_task(repo, branch: 'inv@lid name', lines: ['task'])
+    status, _, executed = run_start_task(repo, branch: 'inv@lid name', lines: ['task'])
+    refute executed, 'editor should not run when branch creation fails'
     assert status.exitstatus != 0
     # no branch should be created when the branch name is invalid
     refute `git -C #{repo} branch --list 'inv@lid name'`.strip.size > 0


### PR DESCRIPTION
## Summary
- create branch before launching editor in `start-task`
- show VCS error message when branch creation fails
- clean up branch when the editor exits with an error
- capture editor invocation in tests
- adjust README to explain new behaviour

## Testing
- `just test`