### PR TITLE
Expand dirty repo assertions

### DIFF
--- a/bin/lib/vcs_repo.rb
+++ b/bin/lib/vcs_repo.rb
@@ -61,8 +61,8 @@ class VCSRepo
     Dir.chdir(@root) do
       case @vcs_type
       when :git
-        system("git add #{file_path}")
-        system("git commit -m '#{message}'")
+        system('git', 'add', '--', file_path)
+        system('git', 'commit', '-m', message, '--', file_path)
       when :hg
         system("hg add #{file_path}")
         system("hg commit -m '#{message}'")


### PR DESCRIPTION
## Summary
- extract common branch assertions into helper
- verify dirty repo cases create the correct commit
- keep staged changes intact when running `start-task`

## Testing
- `just test`
