### PR TITLE
Fix Mercurial commit parsing

### DIFF
--- a/bin/lib/vcs_repo.rb
+++ b/bin/lib/vcs_repo.rb
@@ -174,7 +174,9 @@ class VCSRepo
       when :git
         `git rev-parse #{branch}`.strip
       when :hg
-        `hg log -r #{branch} --template '{node}'`.strip
+        commit = `hg log -r #{branch} --template '{node}'`.strip
+        commit = commit[1..-2] if commit.start_with?("'") && commit.end_with?("'")
+        commit
       else
         ''
       end


### PR DESCRIPTION
## Summary
- strip surrounding quotes from `hg log` output when reading tip commits

## Testing
- `just lint`
- `just test`
