### PR TITLE
Fix Windows CI issue for start-agent-task

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -1,1 +1,2 @@
 The VCSRepo helper abstracts Git, Mercurial, Bazaar and Fossil commands.
+

--- a/bin/agent-task
+++ b/bin/agent-task
@@ -52,6 +52,8 @@ end
 tempfile.close
 
 task_content = File.read(tempfile.path)
+# Normalize CRLF line endings from editors to avoid Fossil commit issues
+task_content.gsub!("\r\n", "\n")
 
 # Create the agents task file path
 now = Time.now.utc
@@ -74,7 +76,9 @@ repo.commit_file(task_file, commit_msg)
 
 # Ask to push to default remote
 print 'Push to default remote? [Y/n]: '
-answer = $stdin.gets.strip
+# STDIN.gets returns nil in non-interactive environments such as CI
+input = $stdin.gets
+answer = input ? input.strip : 'n'
 answer = 'y' if answer.empty?
 repo.push_current_branch(branch_name) if answer.downcase.start_with?('y')
 


### PR DESCRIPTION
## Summary
- normalize CRLF line endings when writing tasks
- handle missing stdin input to avoid NilClass error
- add note about CI behavior and line endings
- move CI insight comment inline next to the code

## Testing
- `just test`
- `just lint`
