### PR TITLE
Add flexible task prompts

### DIFF
--- a/bin/agent-task
+++ b/bin/agent-task
@@ -7,6 +7,12 @@ require 'time'
 require 'optparse'
 require_relative 'lib/vcs_repo'
 
+EDITOR_HINT = <<~HINT
+  # Please write your task prompt above.
+  # Enter an empty prompt to abort the task creation process.
+  # Feel free to leave this comment in the file. It will be ignored.
+HINT
+
 def find_default_editor
   return ENV['EDITOR'] if ENV['EDITOR']
 
@@ -19,10 +25,29 @@ OptionParser.new do |opts|
   opts.on('--push-to-remote=BOOL', 'Push branch to remote automatically') do |val|
     options[:push_to_remote] = val
   end
+  opts.on('--prompt=STRING', 'Use STRING as the task prompt') do |val|
+    options[:prompt] = val
+  end
+  opts.on('--prompt-file=FILE', 'Read the task prompt from FILE') do |val|
+    options[:prompt_file] = val
+  end
 end.parse!(ARGV)
 
 branch_name = ARGV.shift
 abort("Usage: #{File.basename(__FILE__)} <branch-name>") if branch_name.nil? || branch_name.strip.empty?
+
+abort('Error: --prompt and --prompt-file are mutually exclusive') if options[:prompt] && options[:prompt_file]
+
+prompt_content = nil
+if options[:prompt]
+  prompt_content = options[:prompt].dup
+elsif options[:prompt_file]
+  begin
+    prompt_content = File.read(options[:prompt_file])
+  rescue StandardError => e
+    abort("Error: Failed to read prompt file: #{e.message}")
+  end
+end
 
 # Initialize repository and create branch first
 begin
@@ -41,11 +66,36 @@ rescue StandardError => e
   exit 1
 end
 
-# Create a temporary file for the task description
-tempfile = Tempfile.new(['task', '.txt'])
+# Obtain the task description
+task_content = nil
+if prompt_content.nil?
+  tempfile = Tempfile.new(['task', '.txt'])
+  tempfile.write("\n")
+  tempfile.write(EDITOR_HINT)
+  tempfile.close
 
-editor = find_default_editor
-unless system("#{editor} #{tempfile.path}")
+  editor = find_default_editor
+  unless system("#{editor} #{tempfile.path}")
+    repo.checkout_branch(orig_branch) if orig_branch
+    case repo.vcs_type
+    when :git
+      system('git', 'branch', '-D', branch_name,
+             chdir: repo.root, out: File::NULL, err: File::NULL)
+    when :fossil
+      system('fossil', 'branch', 'close', branch_name,
+             chdir: repo.root, out: File::NULL, err: File::NULL)
+    end
+    abort('Error: Failed to open the editor.')
+  end
+  task_content = File.read(tempfile.path)
+  task_content.sub!("\n#{EDITOR_HINT}", '')
+  task_content.sub!(EDITOR_HINT, '')
+else
+  task_content = prompt_content
+end
+# Normalize CRLF line endings from editors and prompts to avoid Fossil commit issues
+task_content.gsub!("\r\n", "\n")
+if task_content.strip.empty?
   repo.checkout_branch(orig_branch) if orig_branch
   case repo.vcs_type
   when :git
@@ -55,13 +105,8 @@ unless system("#{editor} #{tempfile.path}")
     system('fossil', 'branch', 'close', branch_name,
            chdir: repo.root, out: File::NULL, err: File::NULL)
   end
-  abort('Error: Failed to open the editor.')
+  abort('Aborted: empty task prompt.')
 end
-tempfile.close
-
-task_content = File.read(tempfile.path)
-# Normalize CRLF line endings from editors to avoid Fossil commit issues
-task_content.gsub!("\r\n", "\n")
 
 # Create the agents task file path
 now = Time.now.utc


### PR DESCRIPTION
## Summary
- abort task creation if the prompt is empty
- allow non-interactive prompts via `--prompt` or `--prompt-file`
- extend tests to cover new options and abort behaviour

## Testing
- `just lint`
- `just test`