### PR TITLE
Implement prompt options cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository provides an opinionated workflow designed to enhance collaborati
 
 The core components include:
 -   `codex-setup`: A script to initialize the workspace, download necessary internet resources, and run project-specific setup.
--   `start-task`: A script for developers to begin a new task, automatically creating a dedicated branch and storing the task description.
+-   `agent-task`: A script for developers to begin a new task, automatically creating a dedicated branch and storing the task description.
 -   `get-task`: A script for the coding agent to retrieve its current task instructions.
 -   `download-internet-resources`: A helper script that scans task descriptions for URLs and downloads them (or clones Git repositories) for offline access.
 
@@ -34,10 +34,10 @@ This process will:
 ## Using the Workflow
 
 1.  **Starting a Task (Developer):**
-    When a developer needs to assign a task to the agent, they run the `start-task` command with the desired branch name:
+    When a developer needs to assign a task to the agent, they run the `agent-task` command with the desired branch name:
 
     ```bash
-    start-task <branch-name>
+    agent-task <branch-name>
     ```
 
     This script will:
@@ -46,6 +46,12 @@ This process will:
     -   Prompt the developer to enter the task description in an editor.
     -   Commit the task description to a file within a `.agents/tasks/` directory on the new branch.
     -   Push the branch to the default remote.
+    
+    The command accepts a few options for non-interactive use:
+    
+    - `--push-to-remote=BOOL` – automatically push to the default remote without prompting.
+    - `--prompt=STRING` – use `STRING` as the task description instead of launching an editor.
+    - `--prompt-file=FILE` – read the task description from `FILE`.
 
 2.  **Retrieving a Task (Coding Agent):**
     Once the developer has set up the task and switched Codex to the new branch, they instruct the agent to retrieve its instructions. A typical prompt for Codex would be:

--- a/bin/agent-task
+++ b/bin/agent-task
@@ -66,17 +66,72 @@ rescue StandardError => e
   exit 1
 end
 
-# Obtain the task description
-task_content = nil
-if prompt_content.nil?
-  tempfile = Tempfile.new(['task', '.txt'])
-  tempfile.write("\n")
-  tempfile.write(EDITOR_HINT)
-  tempfile.close
+# Set up branch cleanup in case we abort
+cleanup_branch = true
 
-  editor = find_default_editor
-  unless system("#{editor} #{tempfile.path}")
-    repo.checkout_branch(orig_branch) if orig_branch
+begin
+  # Obtain the task description
+  task_content = nil
+  if prompt_content.nil?
+    tempfile = Tempfile.new(['task', '.txt'])
+    tempfile.write("\n")
+    tempfile.write(EDITOR_HINT)
+    tempfile.close
+
+    editor = find_default_editor
+    abort('Error: Failed to open the editor.') unless system("#{editor} #{tempfile.path}")
+
+    task_content = File.read(tempfile.path)
+    task_content.sub!("\n#{EDITOR_HINT}", '')
+    task_content.sub!(EDITOR_HINT, '')
+  else
+    task_content = prompt_content
+  end
+  # Normalize CRLF line endings from editors and prompts to avoid Fossil commit issues
+  task_content.gsub!("\r\n", "\n")
+  abort('Aborted: empty task prompt.') if task_content.strip.empty?
+
+  # Create the agents task file path
+  now = Time.now.utc
+  year = now.year
+  month = format('%02d', now.month)
+  day = format('%02d', now.day)
+  hour = format('%02d', now.hour)
+  min = format('%02d', now.min)
+  filename = "#{day}-#{hour}#{min}-#{branch_name}"
+  tasks_dir = File.join(repo.root, '.agents', 'tasks', year.to_s, month)
+  FileUtils.mkdir_p(tasks_dir)
+  task_file = File.join(tasks_dir, filename)
+  commit_msg = "start-agent-task: #{branch_name}"
+
+  # Write the task content without automatic CRLF conversion
+  File.binwrite(task_file, task_content)
+
+  # Add and commit the file
+  repo.commit_file(task_file, commit_msg)
+
+  # Ask to push to default remote
+  push = nil
+  if options.key?(:push_to_remote)
+    val = options[:push_to_remote].to_s.downcase
+    truthy = %w[1 true yes y].include?(val)
+    falsy = %w[0 false no n].include?(val)
+    abort("Error: Invalid value for --push-to-remote: '#{options[:push_to_remote]}'") unless truthy || falsy
+    push = truthy
+  else
+    print 'Push to default remote? [Y/n]: '
+    input = $stdin.gets
+    abort('Error: Non-interactive environment, use --push-to-remote option.') if input.nil?
+    answer = input.strip
+    answer = 'y' if answer.empty?
+    push = answer.downcase.start_with?('y')
+  end
+  repo.push_current_branch(branch_name) if push
+
+  cleanup_branch = false
+ensure
+  repo.checkout_branch(orig_branch) if orig_branch
+  if cleanup_branch
     case repo.vcs_type
     when :git
       system('git', 'branch', '-D', branch_name,
@@ -85,65 +140,5 @@ if prompt_content.nil?
       system('fossil', 'branch', 'close', branch_name,
              chdir: repo.root, out: File::NULL, err: File::NULL)
     end
-    abort('Error: Failed to open the editor.')
   end
-  task_content = File.read(tempfile.path)
-  task_content.sub!("\n#{EDITOR_HINT}", '')
-  task_content.sub!(EDITOR_HINT, '')
-else
-  task_content = prompt_content
 end
-# Normalize CRLF line endings from editors and prompts to avoid Fossil commit issues
-task_content.gsub!("\r\n", "\n")
-if task_content.strip.empty?
-  repo.checkout_branch(orig_branch) if orig_branch
-  case repo.vcs_type
-  when :git
-    system('git', 'branch', '-D', branch_name,
-           chdir: repo.root, out: File::NULL, err: File::NULL)
-  when :fossil
-    system('fossil', 'branch', 'close', branch_name,
-           chdir: repo.root, out: File::NULL, err: File::NULL)
-  end
-  abort('Aborted: empty task prompt.')
-end
-
-# Create the agents task file path
-now = Time.now.utc
-year = now.year
-month = format('%02d', now.month)
-day = format('%02d', now.day)
-hour = format('%02d', now.hour)
-min = format('%02d', now.min)
-filename = "#{day}-#{hour}#{min}-#{branch_name}"
-tasks_dir = File.join(repo.root, '.agents', 'tasks', year.to_s, month)
-FileUtils.mkdir_p(tasks_dir)
-task_file = File.join(tasks_dir, filename)
-commit_msg = "start-agent-task: #{branch_name}"
-
-# Write the task content without automatic CRLF conversion
-File.binwrite(task_file, task_content)
-
-# Add and commit the file
-repo.commit_file(task_file, commit_msg)
-
-# Ask to push to default remote
-push = nil
-if options.key?(:push_to_remote)
-  val = options[:push_to_remote].to_s.downcase
-  truthy = %w[1 true yes y].include?(val)
-  falsy = %w[0 false no n].include?(val)
-  abort("Error: Invalid value for --push-to-remote: '#{options[:push_to_remote]}'") unless truthy || falsy
-  push = truthy
-else
-  print 'Push to default remote? [Y/n]: '
-  input = $stdin.gets
-  abort('Error: Non-interactive environment, use --push-to-remote option.') if input.nil?
-  answer = input.strip
-  answer = 'y' if answer.empty?
-  push = answer.downcase.start_with?('y')
-end
-repo.push_current_branch(branch_name) if push
-
-# Return to original branch
-repo.checkout_branch(orig_branch) if orig_branch

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,0 +1,3 @@
+# Test guidelines
+
+- Always include a brief comment before each assertion explaining why the assertion is made. This helps future contributors understand the intent of the test.

--- a/test/test_start_task.rb
+++ b/test/test_start_task.rb
@@ -40,6 +40,7 @@ module StartTaskCases # rubocop:disable Metrics/ModuleLength
   def test_clean_repo
     repo, remote = setup_repo(self.class::VCS_TYPE)
     status, = run_agent_task(repo, branch: 'feature', lines: ['task'], push_to_remote: true)
+    # agent-task should succeed
     assert_equal 0, status.exitstatus
     assert_task_branch_created(repo, remote, 'feature')
   ensure
@@ -54,6 +55,7 @@ module StartTaskCases # rubocop:disable Metrics/ModuleLength
     r.add_file('foo.txt')
     status_before = r.working_copy_status
     status, = run_agent_task(repo, branch: 's1', lines: ['task'], push_to_remote: true)
+    # agent-task should succeed
     assert_equal 0, status.exitstatus
     # ensure staged changes are preserved and nothing else changed
     after = r.working_copy_status
@@ -70,6 +72,7 @@ module StartTaskCases # rubocop:disable Metrics/ModuleLength
     r = VCSRepo.new(repo)
     status_before = r.working_copy_status
     status, = run_agent_task(repo, branch: 's2', lines: ['task'], push_to_remote: true)
+    # agent-task should succeed
     assert_equal 0, status.exitstatus
     # unstaged modifications should remain exactly as they were
     after = r.working_copy_status
@@ -83,6 +86,7 @@ module StartTaskCases # rubocop:disable Metrics/ModuleLength
   def test_editor_failure
     repo, remote = setup_repo(self.class::VCS_TYPE)
     status, = run_agent_task(repo, branch: 'bad', lines: [], editor_exit: 1, push_to_remote: false)
+    # agent-task should fail when the editor exits with a non-zero status
     assert status.exitstatus != 0
     # when the editor fails, no branch should have been created
     refute VCSRepo.new(repo).branch_exists?('bad')
@@ -94,6 +98,7 @@ module StartTaskCases # rubocop:disable Metrics/ModuleLength
   def test_empty_file
     repo, remote = setup_repo(self.class::VCS_TYPE)
     status, = run_agent_task(repo, branch: 'empty', lines: [], push_to_remote: false)
+    # an empty task should cause agent-task to fail
     assert status.exitstatus != 0
     refute VCSRepo.new(repo).branch_exists?('empty')
   ensure
@@ -104,6 +109,7 @@ module StartTaskCases # rubocop:disable Metrics/ModuleLength
   def test_prompt_option
     repo, remote = setup_repo(self.class::VCS_TYPE)
     status, = run_agent_task(repo, branch: 'p1', prompt: 'prompt text', push_to_remote: true)
+    # agent-task should succeed when --prompt is provided
     assert_equal 0, status.exitstatus
     assert_task_branch_created(repo, remote, 'p1')
   ensure
@@ -117,6 +123,7 @@ module StartTaskCases # rubocop:disable Metrics/ModuleLength
     file = File.join(dir, 'msg.txt')
     File.write(file, "file text\n")
     status, = run_agent_task(repo, branch: 'pf1', prompt_file: file, push_to_remote: true)
+    # agent-task should succeed when --prompt-file is provided
     assert_equal 0, status.exitstatus
     assert_task_branch_created(repo, remote, 'pf1')
   ensure
@@ -128,6 +135,7 @@ module StartTaskCases # rubocop:disable Metrics/ModuleLength
   def test_prompt_option_empty
     repo, remote = setup_repo(self.class::VCS_TYPE)
     status, = run_agent_task(repo, branch: 'poe', prompt: '   ', push_to_remote: false)
+    # a blank prompt should result in failure
     assert status.exitstatus != 0
     refute VCSRepo.new(repo).branch_exists?('poe')
   ensure
@@ -141,6 +149,7 @@ module StartTaskCases # rubocop:disable Metrics/ModuleLength
     file = File.join(dir, 'msg.txt')
     File.write(file, "\n")
     status, = run_agent_task(repo, branch: 'pfe', prompt_file: file, push_to_remote: false)
+    # a blank prompt file should result in failure
     assert status.exitstatus != 0
     refute VCSRepo.new(repo).branch_exists?('pfe')
   ensure
@@ -153,6 +162,7 @@ module StartTaskCases # rubocop:disable Metrics/ModuleLength
     repo, remote = setup_repo(self.class::VCS_TYPE)
     status, _, executed = run_agent_task(repo, branch: 'inv@lid name', lines: ['task'], push_to_remote: false)
     refute executed, 'editor should not run when branch creation fails'
+    # the command should fail when the branch name is invalid
     assert status.exitstatus != 0
     # no branch should be created when the branch name is invalid
     refute VCSRepo.new(repo).branch_exists?('inv@lid name')


### PR DESCRIPTION
## Summary
- document agent-task options in README
- refactor branch cleanup logic in agent-task
- clarify assertions in tests
- document assertion guideline for tests

## Testing
- `just lint`
- `just test`