### PR TITLE
Add follow-up task support

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -63,6 +63,8 @@ When get-task is executed with --autopush, the system:
 VCSRepo class supports:
 - default_remote_http_url(): Gets HTTP URL of default remote with SSH-to-HTTPS conversion
 - commit_message(commit_hash): Retrieves commit message for specific commit
+- latest_agent_branch_commit(): Finds the last commit containing the
+  'Start-Agent-Branch:' marker in the current branch
 - SSH URL conversion handles multiple formats:
   - git@host:path -> https://host/path
   - ssh://git@host/path -> https://host/path

--- a/README.md
+++ b/README.md
@@ -45,18 +45,21 @@ The primary goal of this workflow is to:
 1.  **Starting a Task (Developer):**
 
     When a developer needs to assign a task to the agent, they run
-    the `agent-task` command with the desired branch name:
+    the `agent-task` command. If a branch name is provided it starts a
+    new branch, otherwise it appends a follow-up task on the current
+    branch.
 
     ```bash
-    agent-task <branch-name>
+    agent-task [branch-name]
     ```
 
     This script will:
-    -   Create the branch first and abort early with the VCS error message
-        if the name is invalid.
+    -   When a branch name is supplied, create the branch first and abort
+        early with the VCS error message if the name is invalid.
     -   Prompt the developer to enter the task description in an editor.
     -   Commit the task description to a file within a `.agents/tasks/`
-        directory on the new branch.
+        directory on the new branch or append it as a follow-up task if
+        no branch was given.
     -   Push the branch to the default remote.
 
     The command accepts a few options for non-interactive use:

--- a/test/test_follow_up_tasks.rb
+++ b/test/test_follow_up_tasks.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'tmpdir'
+require 'fileutils'
+require_relative 'test_helper'
+
+module FollowUpCases
+  def test_append_follow_up_tasks
+    RepoTestHelper::AGENT_TASK_BINARIES.product(RepoTestHelper::GET_TASK_BINARIES).each do |ab, gb|
+      repo, remote = setup_repo(self.class::VCS_TYPE)
+      status, = run_agent_task(repo, branch: 'feat', lines: ['task one'], push_to_remote: true, tool: ab)
+      assert_equal 0, status.exitstatus, 'initial task failed'
+      r = VCSRepo.new(repo)
+      r.checkout_branch('feat')
+      File.write(File.join(repo, 'work.txt'), 'work')
+      r.commit_file(File.join(repo, 'work.txt'), 'work commit')
+      status2, = run_agent_task(repo, branch: nil, lines: ['task two'], push_to_remote: true, tool: ab)
+      assert_equal 0, status2.exitstatus, 'follow-up task failed'
+      status3, output = run_get_task(repo, tool: gb)
+      assert_equal 0, status3.exitstatus, 'get-task failed after follow-up'
+      assert_includes output, 'task one', 'original task missing'
+      assert_includes output, 'task two', 'follow-up task missing'
+    ensure
+      FileUtils.remove_entry(repo) if repo && File.exist?(repo)
+      FileUtils.remove_entry(remote) if remote && File.exist?(remote)
+    end
+  end
+
+  def test_refuse_on_main_branch
+    RepoTestHelper::AGENT_TASK_BINARIES.each do |ab|
+      repo, remote = setup_repo(self.class::VCS_TYPE)
+      status, = run_agent_task(repo, branch: nil, lines: ['bad'], push_to_remote: false, tool: ab)
+      assert status.exitstatus != 0, 'expected failure on main branch'
+    ensure
+      FileUtils.remove_entry(repo) if repo && File.exist?(repo)
+      FileUtils.remove_entry(remote) if remote && File.exist?(remote)
+    end
+  end
+
+  def test_nested_branch_tasks
+    RepoTestHelper::AGENT_TASK_BINARIES.product(RepoTestHelper::GET_TASK_BINARIES).each do |ab, gb|
+      repo, remote = setup_repo(self.class::VCS_TYPE)
+      status, = run_agent_task(repo, branch: 'a', lines: ['task a'], push_to_remote: true, tool: ab)
+      assert_equal 0, status.exitstatus, 'branch a failed'
+      r = VCSRepo.new(repo)
+      r.checkout_branch('a')
+      status, = run_agent_task(repo, branch: 'b', lines: ['task b'], push_to_remote: true, tool: ab)
+      assert_equal 0, status.exitstatus, 'branch b failed'
+      r.checkout_branch('b')
+      _, output = run_get_task(repo, tool: gb)
+      assert_includes output, 'task b', 'task b missing'
+      refute_includes output, 'task a', 'task a should not appear in branch b'
+      status, = run_agent_task(repo, branch: 'c', lines: ['task c'], push_to_remote: true, tool: ab)
+      assert_equal 0, status.exitstatus, 'branch c failed'
+      r.checkout_branch('c')
+      _, output = run_get_task(repo, tool: gb)
+      assert_includes output, 'task c', 'task c missing'
+      refute_includes output, 'task b', 'task b should not appear in branch c'
+    ensure
+      FileUtils.remove_entry(repo) if repo && File.exist?(repo)
+      FileUtils.remove_entry(remote) if remote && File.exist?(remote)
+    end
+  end
+end
+
+class FollowUpGitTest < Minitest::Test
+  include RepoTestHelper
+  include FollowUpCases
+  VCS_TYPE = :git
+end
+
+class FollowUpHgTest < Minitest::Test
+  include RepoTestHelper
+  include FollowUpCases
+  VCS_TYPE = :hg
+end
+
+class FollowUpFossilTest < Minitest::Test
+  include RepoTestHelper
+  include FollowUpCases
+  VCS_TYPE = :fossil
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -125,7 +125,8 @@ module RepoTestHelper # rubocop:disable Metrics/ModuleLength
     output = nil
     status = nil
     Dir.chdir(repo) do
-      cmd = windows? ? ['ruby', tool, branch] : [tool, branch]
+      cmd = windows? ? ['ruby', tool] : [tool]
+      cmd << branch if branch
       cmd << "--push-to-remote=#{push_to_remote}" unless push_to_remote.nil?
       cmd << "--prompt=#{prompt}" if prompt
       cmd << "--prompt-file=#{prompt_file}" if prompt_file


### PR DESCRIPTION
## Summary
- allow agent-task to append follow-up tasks when branch name not provided
- reuse the last `Start-Agent-Branch` commit to locate task files
- split task file on follow-up separator in get-task
- update VCSRepo to search for last Start-Agent-Branch commit
- document optional branch handling in README
- add notes about new VCSRepo method
- test follow-up task workflows

## Testing
- `just lint`
- `just test` *(fails: "database is locked" and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6842b74e2b388329b0f1c3a031ae8e25