### PR TITLE
Fix get-task nested repo tests

### DIFF
--- a/.agents/tasks/2025/06/06-2210-fix-tests.txt
+++ b/.agents/tasks/2025/06/06-2210-fix-tests.txt
@@ -1,0 +1,1 @@
+There are some test failures. Fix them

--- a/lib/vcs_repo.rb
+++ b/lib/vcs_repo.rb
@@ -462,9 +462,12 @@ class VCSRepo
     Dir.chdir(@root) do
       case @vcs_type
       when :git
-        `git log -E --grep='^Start-Agent-Branch:' -n 1 --pretty=%H`.strip
+        # Search across all branches to locate the commit that started the
+        # current agent task. This allows retrieving the task even when the
+        # repository is not checked out on the task branch.
+        `git log --all -E --grep='^Start-Agent-Branch:' -n 1 --pretty=%H`.strip
       when :hg
-        revset = "reverse(ancestors(.) and grep('^Start-Agent-Branch:'))"
+        revset = "reverse(grep('^Start-Agent-Branch:'))"
         `hg log -r #{revset} --limit 1 --template '{node}\n'`.strip
       when :fossil
         branch = current_branch


### PR DESCRIPTION
## Summary
- search across all VCS refs when locating the agent branch commit
- record the test failure fix task

## Testing
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_684360000f248329aaff63edad785269