### PR TITLE
Implement start-work command

### DIFF
--- a/bin/start-work
+++ b/bin/start-work
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../lib/agent_task/cli'
+
+AgentTask::CLI.run_start_work(ARGV)

--- a/common-post-setup
+++ b/common-post-setup
@@ -39,3 +39,6 @@ fi
 # Create the get-task symlink in the chosen directory
 sudo ln -sf "$TEMP_AGENTS_DIR/bin/get-task" "$BIN_DIR/get-task"
 echo "get-task installed to $BIN_DIR/get-task"
+# Create the start-work symlink as well
+sudo ln -sf "$TEMP_AGENTS_DIR/bin/start-work" "$BIN_DIR/start-work"
+echo "start-work installed to $BIN_DIR/start-work"

--- a/scripts/gem_start_work.rb
+++ b/scripts/gem_start_work.rb
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'agent_task'
+
+AgentTask::CLI.run_start_work(ARGV)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,7 @@ module RepoTestHelper # rubocop:disable Metrics/ModuleLength
   GET_TASK_GEM = File.join(GEM_HOME, 'bin', 'get-task')
   GEM_AGENT_TASK_SCRIPT = File.join(ROOT, 'scripts', 'gem_agent_task.rb')
   GEM_GET_TASK_SCRIPT = File.join(ROOT, 'scripts', 'gem_get_task.rb')
+  GEM_START_WORK_SCRIPT = File.join(ROOT, 'scripts', 'gem_start_work.rb')
   GEM_ENV = {
     'GEM_HOME' => GEM_HOME,
     'GEM_PATH' => GEM_HOME,
@@ -35,6 +36,9 @@ module RepoTestHelper # rubocop:disable Metrics/ModuleLength
 
   AGENT_TASK_BINARIES = [AGENT_TASK, AGENT_TASK_GEM, GEM_AGENT_TASK_SCRIPT].freeze
   GET_TASK_BINARIES = [GET_TASK, GET_TASK_GEM, GEM_GET_TASK_SCRIPT].freeze
+  START_WORK = File.join(ROOT, 'bin', 'start-work')
+  START_WORK_GEM = File.join(GEM_HOME, 'bin', 'start-work')
+  START_WORK_BINARIES = [START_WORK, START_WORK_GEM, GEM_START_WORK_SCRIPT].freeze
 
   def windows?
     RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
@@ -167,6 +171,17 @@ module RepoTestHelper # rubocop:disable Metrics/ModuleLength
   # rubocop:enable Metrics/ParameterLists
 
   def run_get_task(working_dir, tool: GET_TASK)
+    output = nil
+    status = nil
+    Dir.chdir(working_dir) do
+      cmd = windows? ? ['ruby', tool] : [tool]
+      output = IO.popen(GEM_ENV, cmd, &:read)
+      status = $CHILD_STATUS
+    end
+    [status, output]
+  end
+
+  def run_start_work(working_dir, tool: START_WORK)
     output = nil
     status = nil
     Dir.chdir(working_dir) do

--- a/test/test_start_work_command.rb
+++ b/test/test_start_work_command.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'tmpdir'
+require 'fileutils'
+require_relative 'test_helper'
+
+module StartWorkCases
+  def assert_work_setup(repo, remote_url)
+    # remote should be added correctly
+    assert_equal remote_url, capture(repo, 'git', 'remote', 'get-url', 'target_remote')
+    # user.name should match the last commit author
+    assert_equal 'Tester', capture(repo, 'git', 'config', '--get', 'user.name')
+    # user.email should also match
+    assert_equal 'tester@example.com', capture(repo, 'git', 'config', '--get', 'user.email')
+  end
+
+  def test_start_work_after_start
+    RepoTestHelper::AGENT_TASK_BINARIES.product(RepoTestHelper::START_WORK_BINARIES).each do |ab, sb|
+      repo, remote = setup_repo(self.class::VCS_TYPE)
+      status, = run_agent_task(repo, branch: 'feat', lines: ['task'], push_to_remote: true, tool: ab)
+      # agent-task should succeed
+      assert_equal 0, status.exitstatus
+      VCSRepo.new(repo).checkout_branch('feat')
+      status2, = run_start_work(repo, tool: sb)
+      # start-work should succeed
+      assert_equal 0, status2.exitstatus
+      assert_work_setup(repo, remote)
+    ensure
+      FileUtils.remove_entry(repo) if repo && File.exist?(repo)
+      FileUtils.remove_entry(remote) if remote && File.exist?(remote)
+    end
+  end
+
+  def test_start_work_on_work_branch
+    RepoTestHelper::AGENT_TASK_BINARIES.product(RepoTestHelper::START_WORK_BINARIES).each do |ab, sb|
+      repo, remote = setup_repo(self.class::VCS_TYPE)
+      status, = run_agent_task(repo, branch: 'feat', lines: ['other'], push_to_remote: true, tool: ab)
+      # agent-task should succeed
+      assert_equal 0, status.exitstatus
+      r = VCSRepo.new(repo)
+      r.checkout_branch('feat')
+      r.create_local_branch('work')
+      status2, = run_start_work(repo, tool: sb)
+      # start-work should succeed on a different branch
+      assert_equal 0, status2.exitstatus
+      assert_work_setup(repo, remote)
+    ensure
+      FileUtils.remove_entry(repo) if repo && File.exist?(repo)
+      FileUtils.remove_entry(remote) if remote && File.exist?(remote)
+    end
+  end
+
+  def test_start_work_from_parent_directory
+    RepoTestHelper::AGENT_TASK_BINARIES.product(RepoTestHelper::START_WORK_BINARIES).each do |ab, sb|
+      repo, remote = setup_repo(self.class::VCS_TYPE)
+      status, = run_agent_task(repo, branch: 'feat', lines: ['outer'], push_to_remote: true, tool: ab)
+      # agent-task should succeed
+      assert_equal 0, status.exitstatus
+      outer = Dir.mktmpdir('outer')
+      FileUtils.mv(repo, File.join(outer, 'repo'))
+      status2, = run_start_work(outer, tool: sb)
+      # start-work should succeed when launched from parent directory
+      assert_equal 0, status2.exitstatus
+      assert_work_setup(File.join(outer, 'repo'), remote)
+    ensure
+      FileUtils.remove_entry(outer) if outer && File.exist?(outer)
+      FileUtils.remove_entry(remote) if remote && File.exist?(remote)
+    end
+  end
+
+  def test_start_work_from_parent_directory_multiple_repos
+    RepoTestHelper::AGENT_TASK_BINARIES.product(RepoTestHelper::START_WORK_BINARIES).each do |ab, sb|
+      repo_a, remote_a = setup_repo(self.class::VCS_TYPE)
+      status, = run_agent_task(repo_a, branch: 'feat', lines: ['a'], push_to_remote: true, tool: ab)
+      # first repo setup
+      assert_equal 0, status.exitstatus
+      repo_b, remote_b = setup_repo(self.class::VCS_TYPE)
+      status, = run_agent_task(repo_b, branch: 'feat', lines: ['b'], push_to_remote: true, tool: ab)
+      # second repo setup
+      assert_equal 0, status.exitstatus
+      outer = Dir.mktmpdir('outer')
+      FileUtils.mv(repo_a, File.join(outer, 'a'))
+      FileUtils.mv(repo_b, File.join(outer, 'b'))
+      status2, = run_start_work(outer, tool: sb)
+      # start-work should configure all repositories
+      assert_equal 0, status2.exitstatus
+      assert_work_setup(File.join(outer, 'a'), remote_a)
+      assert_work_setup(File.join(outer, 'b'), remote_b)
+    ensure
+      FileUtils.remove_entry(outer) if outer && File.exist?(outer)
+      FileUtils.remove_entry(remote_a) if remote_a && File.exist?(remote_a)
+      FileUtils.remove_entry(remote_b) if remote_b && File.exist?(remote_b)
+    end
+  end
+end
+
+class StartWorkGitTest < Minitest::Test
+  include RepoTestHelper
+  include StartWorkCases
+  VCS_TYPE = :git
+end


### PR DESCRIPTION
## Summary
- add `start-work` command for initializing agent git config
- share repo discovery utilities and refactor autopush message
- install start-work in `common-post-setup`
- provide gem wrapper and binary script
- add comprehensive tests for start-work functionality

## Testing
- `just lint`
- `just test` *(fails: Interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68436450a350832993e7ffbf24a16f1f