### PR TITLE
Add smoke tests for gem binaries

### DIFF
--- a/.agents/tasks/2025/06/07-0206-speed-up-tests.txt
+++ b/.agents/tasks/2025/06/07-0206-speed-up-tests.txt
@@ -1,0 +1,2 @@
+the testing framework takes too much time to run right now.
+i think running the tests with all the binary types (ruby file, gem, gem library wrapper) is a bit redundant, as they are essentially testing the same code. there is value in smoke testing them because there might be issues around library paths and other packaging concerns, but i think if the gem and gem library wrapper work in some basic tests, then they are likely to work in all tests. let's make the test suite faster by executing the gem and the library wrapper in some minimal/reasonable set of tests.

--- a/test/test_binary_smoke.rb
+++ b/test/test_binary_smoke.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'tmpdir'
+require 'fileutils'
+require_relative 'test_helper'
+
+class BinarySmokeTest < Minitest::Test
+  include RepoTestHelper
+
+  def test_all_binaries_start_and_get_task
+    ALL_AGENT_TASK_BINARIES.product(ALL_GET_TASK_BINARIES).each do |ab, gb|
+      repo, remote = setup_repo(:git)
+      status, = run_agent_task(repo, branch: 'feat', lines: ['smoke'], push_to_remote: true, tool: ab)
+      # agent-task should succeed with this binary
+      assert_equal 0, status.exitstatus
+      VCSRepo.new(repo).checkout_branch('feat')
+      status2, output = run_get_task(repo, tool: gb)
+      # get-task should retrieve the task description
+      assert_equal 0, status2.exitstatus
+      assert_includes output, 'smoke'
+    ensure
+      FileUtils.remove_entry(repo) if repo && File.exist?(repo)
+      FileUtils.remove_entry(remote) if remote && File.exist?(remote)
+    end
+  end
+
+  def test_start_work_all_binaries
+    ALL_AGENT_TASK_BINARIES.product(ALL_START_WORK_BINARIES).each do |ab, sb|
+      repo, remote = setup_repo(:git)
+      status, = run_agent_task(repo, branch: 'feat', lines: ['work'], push_to_remote: true, tool: ab)
+      # agent-task should succeed before start-work
+      assert_equal 0, status.exitstatus
+      VCSRepo.new(repo).checkout_branch('feat')
+      status2, = run_start_work(repo, tool: sb)
+      # start-work should configure the repo
+      assert_equal 0, status2.exitstatus
+    ensure
+      FileUtils.remove_entry(repo) if repo && File.exist?(repo)
+      FileUtils.remove_entry(remote) if remote && File.exist?(remote)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,6 +40,10 @@ module RepoTestHelper # rubocop:disable Metrics/ModuleLength
   START_WORK_GEM = File.join(GEM_HOME, 'bin', 'start-work')
   START_WORK_BINARIES = [START_WORK].freeze
 
+  ALL_AGENT_TASK_BINARIES = [AGENT_TASK, AGENT_TASK_GEM, GEM_AGENT_TASK_SCRIPT].freeze
+  ALL_GET_TASK_BINARIES = [GET_TASK, GET_TASK_GEM, GEM_GET_TASK_SCRIPT].freeze
+  ALL_START_WORK_BINARIES = [START_WORK, START_WORK_GEM, GEM_START_WORK_SCRIPT].freeze
+
   def windows?
     RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
   end


### PR DESCRIPTION
## Summary
- add instructions file for speed up tests request
- define lists of all binary variants in the test helper
- add a `BinarySmokeTest` that ensures gem and wrapper binaries work

## Testing
- `just lint`
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_68439deef7e08329b90b911e40023c86