### PR TITLE
Add setup command and refine flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ The primary goal of this workflow is to:
     - `--prompt-file=FILE` – read the task description from `FILE`.
     - `--devshell=NAME` (`-s`) – record the given Nix dev shell in the initial commit message.
 
+    The command also provides a `setup` subcommand that prints the versions of `codex` and `goose` available in the current `PATH`.
+
 2.  **Retrieving a Task (Coding Agent):**
 
     Once the developer has set up the task, they instruct the agent to
@@ -152,12 +154,28 @@ This will provide the `agent-task`, `get-task`, and `download-internet-resources
 
 To enable bash completion for `agent-task`, source the script `scripts/agent-task-completion.bash` in your shell profile.
 
+### Installing with Nix
+
+This repository also provides a Nix flake. The default package installs the `agent-task` binary with `codex` and `goose` available in its `PATH`. An additional `agent-utils` package bundles the `get-task` and `start-work` binaries.
+
+```bash
+nix run github:metacraft-labs/agents-workflow
+```
+
+Or install the utilities package:
+
+```bash
+nix profile install github:metacraft-labs/agents-workflow#agent-utils
+```
+
 ### What's included?
 
 The core components include:
 -   `codex-setup`: A script to initialize the workspace, download necessary internet resources, and run project-specific setup.
 -   `agent-task`: A script for developers to begin a new task, automatically creating a dedicated branch and storing the task description.
+-   `agent-task setup`: Prints the versions of `codex` and `goose` available in `PATH`.
 -   `get-task`: A script for the coding agent to retrieve its current task instructions.
+-   `start-work`: A helper that configures a freshly checked-out repository for development.
 -   `download-internet-resources`: A helper script that scans task descriptions for URLs and downloads them (or clones Git repositories) for offline access.
 
 ## Future Direction

--- a/bin/agent-task
+++ b/bin/agent-task
@@ -2,4 +2,10 @@
 # frozen_string_literal: true
 
 require_relative '../lib/agent_task/cli'
-AgentTask::CLI.start_task(ARGV)
+
+if ARGV.first == 'setup'
+  ARGV.shift
+  AgentTask::CLI.run_setup(ARGV)
+else
+  AgentTask::CLI.start_task(ARGV)
+end

--- a/flake.nix
+++ b/flake.nix
@@ -13,10 +13,23 @@
     packages = forAllSystems (
       system: let
         pkgs = import nixpkgs {inherit system;};
-      in {
-        agent-task = pkgs.writeShellScriptBin "agent-task" ''
-          exec ${pkgs.ruby}/bin/ruby ${./bin/agent-task} "$@"
+        agent-task-script = pkgs.writeShellScriptBin "agent-task" ''
+          PATH=${pkgs.lib.makeBinPath [ pkgs.ruby pkgs.codex pkgs.goose ]}:$PATH
+          exec ruby ${./bin/agent-task} "$@"
         '';
+        get-task = pkgs.writeShellScriptBin "get-task" ''
+          exec ${pkgs.ruby}/bin/ruby ${./bin/get-task} "$@"
+        '';
+        start-work = pkgs.writeShellScriptBin "start-work" ''
+          exec ${pkgs.ruby}/bin/ruby ${./bin/start-work} "$@"
+        '';
+        agent-utils = pkgs.symlinkJoin {
+          name = "agent-utils";
+          paths = [ get-task start-work ];
+        };
+      in {
+        agent-task = agent-task-script;
+        agent-utils = agent-utils;
       }
     );
 

--- a/lib/agent_task/cli.rb
+++ b/lib/agent_task/cli.rb
@@ -335,5 +335,21 @@ module AgentTask
       puts e.message
       exit 1
     end
+
+    def run_setup(_args = [])
+      require 'English'
+
+      codex_version = `codex --version 2>&1`
+      codex_version = $CHILD_STATUS.success? ? codex_version.strip : 'not found'
+
+      goose_version = `goose --version 2>&1`
+      goose_version = $CHILD_STATUS.success? ? goose_version.strip : 'not found'
+
+      puts "codex: #{codex_version}"
+      puts "goose: #{goose_version}"
+    rescue StandardError => e
+      puts e.message
+      exit 1
+    end
   end
 end

--- a/scripts/gem_agent_task.rb
+++ b/scripts/gem_agent_task.rb
@@ -3,4 +3,9 @@
 
 require 'agent_task'
 
-AgentTask::CLI.start_task(ARGV)
+if ARGV.first == 'setup'
+  ARGV.shift
+  AgentTask::CLI.run_setup(ARGV)
+else
+  AgentTask::CLI.start_task(ARGV)
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -198,4 +198,15 @@ module RepoTestHelper # rubocop:disable Metrics/ModuleLength
     end
     [status, output]
   end
+
+  def run_agent_task_setup(working_dir, tool: AGENT_TASK)
+    output = nil
+    status = nil
+    Dir.chdir(working_dir) do
+      cmd = windows? ? ['ruby', tool, 'setup'] : [tool, 'setup']
+      output = IO.popen(GEM_ENV, cmd, &:read)
+      status = $CHILD_STATUS
+    end
+    [status, output]
+  end
 end

--- a/test/test_setup_command.rb
+++ b/test/test_setup_command.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'tmpdir'
+require_relative 'test_helper'
+
+class SetupCommandTest < Minitest::Test
+  include RepoTestHelper
+
+  def test_setup_prints_versions
+    RepoTestHelper::ALL_AGENT_TASK_BINARIES.each do |bin|
+      Dir.mktmpdir('work') do |dir|
+        status, output = run_agent_task_setup(dir, tool: bin)
+        # setup command should succeed
+        assert_equal 0, status.exitstatus
+        # output should mention codex and goose versions
+        assert_match(/codex:/, output)
+        assert_match(/goose:/, output)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add `agent-task setup` subcommand
- package `get-task` and `start-work` as `agent-utils`
- include codex and goose in the `agent-task` PATH through the flake
- document the new flake packages and setup command
- test the setup command

## Testing
- `just lint`
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_6844fd1834188329a1e619dcda1c3f79