### PR TITLE
Implement autopush and task recording in start-work

### DIFF
--- a/codex-setup
+++ b/codex-setup
@@ -31,7 +31,7 @@ When the task description or developer instructions are not "go", before
 you do anything else, record a precise copy of them with the following
 shell command:
 
-start-work --branch-name "<TASK_BRANCH_NAME>" --task-description "<message>"
+start-work --autopush --branch-name "<TASK_BRANCH_NAME>" --task-description "<message>"
 
 TASK_BRANCH_NAME should be an appropriate short branch name that describes
 well the task description or developer instructions.

--- a/lib/agent_task/cli.rb
+++ b/lib/agent_task/cli.rb
@@ -320,6 +320,7 @@ module AgentTask
       end
 
       repos.to_h.each_value do |at|
+        initial_setup = !at.on_task_branch?
         if options[:task_description]
           if at.on_task_branch?
             at.append_task(options[:task_description])
@@ -331,7 +332,8 @@ module AgentTask
             at.record_initial_task(options[:task_description], options[:branch_name])
           end
         end
-        at.prepare_work_environment(autopush: options[:autopush])
+        _, branch = at.prepare_work_environment(autopush: options[:autopush])
+        at.repo.force_push_current_branch('target_remote', branch) if options[:autopush] && initial_setup
       end
     rescue StandardError => e
       puts e.message

--- a/lib/agent_tasks.rb
+++ b/lib/agent_tasks.rb
@@ -105,6 +105,7 @@ class AgentTasks
     raise StandardError, 'Error: Start-Agent-Branch is empty in commit message' if target_branch.empty?
 
     @repo.prepare_work_environment(target_remote, target_branch, autopush: autopush)
+    [target_remote, target_branch]
   end
 
   def agent_prompt(autopush: false)

--- a/test/test_commit_message_format.rb
+++ b/test/test_commit_message_format.rb
@@ -116,7 +116,7 @@ class TestCommitMessageFormat < Minitest::Test
     vcs_repo.checkout_branch('token-test')
     agent_tasks = AgentTasks.new(repo)
 
-    message = agent_tasks.agent_prompt(autopush: true)
+    agent_tasks.agent_prompt(autopush: true)
 
     # Verify that work environment was automatically set up
     remotes = capture(repo, 'git', 'remote').strip.split("\n")


### PR DESCRIPTION
## Summary
- support `--autopush`, `--task-description` and `--branch-name` in `start-work`
- push the initial commit when autopush is enabled
- expose force pushing in `VCSRepo`
- return remote and branch from `AgentTasks#prepare_work_environment`
- update `codex-setup` instructions
- adjust tests for autopush behavior

## Testing
- `just lint`
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_68452a3155d08329a21d85e79c70c142