### PR TITLE
Implement workflow commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ The primary goal of this workflow is to:
 
     The command also provides a `setup` subcommand that prints the versions of `codex` and `goose` available in the current `PATH`.
 
+3.  **Workflow Commands**
+
+    Task descriptions may contain lines starting with `/` followed by a program
+    name and optional arguments. These "workflow commands" are resolved against
+    executables or `.txt` files placed in `.agents/workflows`. When `get-task`
+    runs, each command is executed and its output replaces the command line in
+    the final message. Any lines of the form `@agents-setup VAR=value` in either
+    the task description or the workflow output are stripped and collected. The
+    aggregated environment can be printed with `get-task --get-setup-env` and is
+    automatically applied by the provided `*-setup` scripts before they invoke
+    project specific setup hooks.
+
 2.  **Retrieving a Task (Coding Agent):**
 
     Once the developer has set up the task, they instruct the agent to
@@ -104,6 +116,11 @@ Each agent system has a dedicated setup script (e.g., `codex-setup`, `jules-setu
 3. `.agents/common-post-setup` runs last for finalization tasks (if it exists)
 
 This architecture allows you to share common setup logic across all agent systems while customizing setup for specific agents when needed.
+
+Before calling the repository specific setup scripts, each `*-setup` helper
+loads environment variables collected from the task description using `get-task
+--get-setup-env`. This allows workflow commands to configure the environment for
+your own setup hooks.
 
 ## Usage by Agent System
 

--- a/codex-setup
+++ b/codex-setup
@@ -45,6 +45,11 @@ EXECUTED IMMEDIATELY.
 EOF
 
 bash "$AGENTS_WORKFLOW_DIR/common-pre-setup"
+if command -v get-task >/dev/null; then
+  while IFS= read -r line; do
+    export "$line"
+  done < <(get-task --get-setup-env)
+fi
 
 if [ -f .agents/codex-setup ]; then
   .agents/codex-setup

--- a/copilot-setup
+++ b/copilot-setup
@@ -3,6 +3,11 @@
 AGENTS_WORKFLOW_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 bash "$AGENTS_WORKFLOW_DIR/common-pre-setup"
+if command -v get-task >/dev/null; then
+  while IFS= read -r line; do
+    export "$line"
+  done < <(get-task --get-setup-env)
+fi
 
 if [ -f .agents/copilot-setup ]; then
   .agents/copilot-setup

--- a/goose-setup
+++ b/goose-setup
@@ -3,6 +3,11 @@
 AGENTS_WORKFLOW_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 bash "$AGENTS_WORKFLOW_DIR/common-pre-setup"
+if command -v get-task >/dev/null; then
+  while IFS= read -r line; do
+    export "$line"
+  done < <(get-task --get-setup-env)
+fi
 
 if [ -f .agents/goose-setup ]; then
   .agents/goose-setup

--- a/jules-setup
+++ b/jules-setup
@@ -3,6 +3,11 @@
 AGENTS_WORKFLOW_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 bash "$AGENTS_WORKFLOW_DIR/common-pre-setup"
+if command -v get-task >/dev/null; then
+  while IFS= read -r line; do
+    export "$line"
+  done < <(get-task --get-setup-env)
+fi
 
 if [ -f .agents/jules-setup ]; then
   .agents/jules-setup

--- a/lib/agent_tasks.rb
+++ b/lib/agent_tasks.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'vcs_repo'
+require_relative 'workflow_commands'
 require 'fileutils'
 require 'net/http'
 require 'uri'
@@ -107,9 +108,19 @@ class AgentTasks
     @repo.setup_autopush(target_remote, target_branch)
   end
 
+  def task_text_and_env
+    file_contents = File.read(agent_task_file_in_current_branch)
+    WorkflowCommands.process(file_contents, @repo.root)
+  end
+
+  def agent_setup_env
+    _, env = task_text_and_env
+    env
+  end
+
   def agent_prompt
-    task_file_contents = File.read(agent_task_file_in_current_branch)
-    tasks = task_file_contents.split("\n--- FOLLOW UP TASK ---\n")
+    text, = task_text_and_env
+    tasks = text.split("\n--- FOLLOW UP TASK ---\n")
     if tasks.length == 1
       message = tasks[0]
     else

--- a/lib/workflow_commands.rb
+++ b/lib/workflow_commands.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require 'shellwords'
+require 'open3'
+
+# WorkflowCommands provides helpers for processing special workflow commands
+# embedded in task descriptions. Workflow commands are lines starting with '/'
+# followed by a program name and optional arguments. The commands are searched
+# under `.agents/workflows` within the repository.
+module WorkflowCommands # rubocop:disable Metrics/ModuleLength
+  module_function
+
+  # Execute the workflow command or include the matching text file.
+  # Returns [output_string, env_hash].
+  def run(name, args, repo_root)
+    workflows_dir = File.join(repo_root, '.agents', 'workflows')
+    script = File.join(workflows_dir, name)
+    text = File.join(workflows_dir, "#{name}.txt")
+
+    raise "Unknown workflow command '#{name}'" unless File.exist?(script) || File.exist?(text)
+
+    return [File.read(text), {}] if File.exist?(text)
+
+    unless File.executable?(script)
+      begin
+        File.chmod(0o755, script)
+      rescue StandardError
+        # ignore
+      end
+    end
+
+    raise "Workflow command '#{name}' is not executable" unless File.executable?(script)
+
+    stdout, stderr, status = Open3.capture3(script, *args, chdir: repo_root)
+    raise "Error running workflow command '#{name}':\n#{stderr}" unless status.success?
+
+    output, env = extract_env_directives(stdout)
+    [output, env]
+  end
+
+  # Parse a task description and execute workflow commands. Returns
+  # [processed_text, env_hash].
+  def process(text, repo_root)
+    env = {}
+    result_lines = []
+    text.each_line do |line|
+      if (cmd = parse_command(line))
+        name, *args = cmd
+        out, sub_env = run(name, args, repo_root)
+        check_conflicts!(env, sub_env)
+        env.merge!(sub_env)
+        out.each_line do |l|
+          next if l.strip.start_with?('@agents-setup')
+
+          result_lines << l
+        end
+      elsif (assigns = parse_env(line))
+        check_conflicts!(env, assigns)
+        env.merge!(assigns)
+      else
+        result_lines << line
+      end
+    end
+    [result_lines.join, env]
+  end
+
+  # Validate the task description without producing output. Returns array of
+  # error messages.
+  def validate(text, repo_root)
+    env = {}
+    errors = []
+    text.each_line do |line|
+      if (cmd = parse_command(line))
+        name, *args = cmd
+        begin
+          _, sub_env = run(name, args, repo_root)
+          begin
+            check_conflicts!(env, sub_env)
+            env.merge!(sub_env)
+          rescue StandardError => e
+            errors << e.message
+          end
+        rescue StandardError => e
+          errors << e.message
+        end
+      elsif (assigns = parse_env(line))
+        begin
+          check_conflicts!(env, assigns)
+          env.merge!(assigns)
+        rescue StandardError => e
+          errors << e.message
+        end
+      end
+    end
+    errors
+  end
+
+  def parse_command(line)
+    return nil unless line.lstrip.start_with?('/')
+
+    Shellwords.shellsplit(line.strip.sub(%r{^/}, ''))
+  rescue ArgumentError
+    nil
+  end
+
+  def parse_env(line)
+    m = line.strip.match(/^@agents-setup\s+(.+)/)
+    return nil unless m
+
+    assignments = {}
+    Shellwords.shellsplit(m[1]).each do |assign|
+      k, v = assign.split('=', 2)
+      assignments[k] = v || ''
+    end
+    assignments
+  rescue ArgumentError
+    nil
+  end
+
+  def check_conflicts!(env, assigns)
+    assigns.each do |k, v|
+      next unless env.key?(k) && env[k] != v
+
+      raise "Conflicting @agents-setup value for #{k}"
+    end
+  end
+
+  def extract_env_directives(output)
+    env = {}
+    lines = []
+    output.each_line do |line|
+      if (assigns = parse_env(line))
+        check_conflicts!(env, assigns)
+        env.merge!(assigns)
+      else
+        lines << line
+      end
+    end
+    [lines.join, env]
+  end
+end

--- a/open-hands-setup
+++ b/open-hands-setup
@@ -3,6 +3,11 @@
 AGENTS_WORKFLOW_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 bash "$AGENTS_WORKFLOW_DIR/common-pre-setup"
+if command -v get-task >/dev/null; then
+  while IFS= read -r line; do
+    export "$line"
+  done < <(get-task --get-setup-env)
+fi
 
 # We want to run
 if [ -f .agents/open-hands-setup ]; then

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -183,11 +183,12 @@ module RepoTestHelper # rubocop:disable Metrics/ModuleLength
   end
   # rubocop:enable Metrics/ParameterLists
 
-  def run_get_task(working_dir, tool: GET_TASK)
+  def run_get_task(working_dir, tool: GET_TASK, args: [])
     output = nil
     status = nil
     Dir.chdir(working_dir) do
       cmd = windows? ? ['ruby', tool] : [tool]
+      cmd.concat(args)
       output = IO.popen(GEM_ENV, cmd, &:read)
       status = $CHILD_STATUS
     end

--- a/test/test_workflows.rb
+++ b/test/test_workflows.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'tmpdir'
+require 'fileutils'
+require_relative 'test_helper'
+
+class WorkflowTest < Minitest::Test
+  include RepoTestHelper
+
+  def prepare_workflows(dir)
+    flow_dir = File.join(dir, '.agents', 'workflows')
+    FileUtils.mkdir_p(flow_dir)
+    File.write(File.join(flow_dir, 'sh'), "#!/bin/bash\necho shell\necho '@agents-setup SH=1'\n")
+    File.chmod(0o644, File.join(flow_dir, 'sh'))
+    File.write(File.join(flow_dir, 'rb'), "#!/usr/bin/env ruby\nputs 'ruby'\nputs '@agents-setup RB=2'\n")
+    File.chmod(0o755, File.join(flow_dir, 'rb'))
+    File.write(File.join(flow_dir, 'msg.txt'), "text line\n")
+  end
+
+  def test_workflow_commands
+    RepoTestHelper::AGENT_TASK_BINARIES.product(RepoTestHelper::GET_TASK_BINARIES).each do |ab, gb|
+      repo, remote = setup_repo(:git)
+      prepare_workflows(repo)
+      status, = run_agent_task(repo, branch: 'feat', lines: ['start', '/sh', '/rb', '/msg'], push_to_remote: false,
+                                     tool: ab)
+      # agent-task should succeed with workflows
+      assert_equal 0, status.exitstatus
+      VCSRepo.new(repo).checkout_branch('feat')
+      status2, output = run_get_task(repo, tool: gb)
+      # outputs of workflows should appear
+      assert_equal 0, status2.exitstatus
+      assert_includes output, 'shell'
+      assert_includes output, 'ruby'
+      assert_includes output, 'text line'
+      refute_includes output, '@agents-setup'
+      status3, env_output = run_get_task(repo, tool: gb, args: ['--get-setup-env'])
+      assert_equal 0, status3.exitstatus
+      assert_includes env_output, 'SH=1'
+      assert_includes env_output, 'RB=2'
+    ensure
+      FileUtils.remove_entry(repo) if repo && File.exist?(repo)
+      FileUtils.remove_entry(remote) if remote && File.exist?(remote)
+    end
+  end
+
+  def test_missing_workflow_errors
+    RepoTestHelper::AGENT_TASK_BINARIES.each do |ab|
+      repo, remote = setup_repo(:git)
+      status, output = run_agent_task(repo, branch: 'bad', lines: ['/missing'], push_to_remote: false, tool: ab)
+      # missing workflow should cause failure
+      assert output.include?('Unknown workflow command')
+      refute_equal 0, status.exitstatus
+    ensure
+      FileUtils.remove_entry(repo) if repo && File.exist?(repo)
+      FileUtils.remove_entry(remote) if remote && File.exist?(remote)
+    end
+  end
+
+  def test_prompt_option_validation
+    RepoTestHelper::AGENT_TASK_BINARIES.each do |ab|
+      repo, remote = setup_repo(:git)
+      status, output, = run_agent_task(repo, branch: 'p1', prompt: '/missing', push_to_remote: false, tool: ab)
+      # prompt mode should exit with error
+      assert output.include?('Unknown workflow command')
+      refute_equal 0, status.exitstatus
+    ensure
+      FileUtils.remove_entry(repo) if repo && File.exist?(repo)
+      FileUtils.remove_entry(remote) if remote && File.exist?(remote)
+    end
+  end
+
+  def test_setup_env_propagation
+    repo, remote = setup_repo(:git)
+    flow_dir = File.join(repo, '.agents', 'workflows')
+    FileUtils.mkdir_p(flow_dir)
+    File.write(File.join(flow_dir, 'env.txt'), "@agents-setup TESTVAR=42\n")
+    FileUtils.mkdir_p(File.join(repo, '.agents'))
+    File.write(File.join(repo, '.agents', 'codex-setup'), "#!/bin/bash\necho $TESTVAR > result.txt\n")
+    File.chmod(0o755, File.join(repo, '.agents', 'codex-setup'))
+    status, = run_agent_task(repo, branch: 'feat', lines: ['/env'], push_to_remote: false, tool: RepoTestHelper::AGENT_TASK)
+    assert_equal 0, status.exitstatus
+    VCSRepo.new(repo).checkout_branch('feat')
+    # clone workflow repo so that codex-setup moves itself safely
+    tmp = Dir.mktmpdir('clone')
+    FileUtils.cp_r(ROOT, File.join(tmp, 'agents-workflow'))
+    bin_dir = Dir.mktmpdir('bin')
+    File.write(File.join(bin_dir, 'sudo'), "#!/bin/sh\nexec \"$@\"\n")
+    File.chmod(0o755, File.join(bin_dir, 'sudo'))
+    env = { 'PATH' => "#{bin_dir}:#{ENV.fetch('PATH', nil)}" }
+    system(env, File.join(tmp, 'agents-workflow', 'codex-setup'), chdir: repo)
+    result = File.read(File.join(repo, 'result.txt'))
+    assert_equal "42\n", result
+  ensure
+    FileUtils.remove_entry(repo) if repo && File.exist?(repo)
+    FileUtils.remove_entry(remote) if remote && File.exist?(remote)
+    FileUtils.remove_entry(tmp) if defined?(tmp) && File.exist?(tmp)
+    FileUtils.remove_entry(bin_dir) if defined?(bin_dir) && File.exist?(bin_dir)
+  end
+end


### PR DESCRIPTION
## Summary
- add WorkflowCommands processor for `/workflow` macros
- integrate workflow processing into agent-task and get-task
- expose `--get-setup-env` option
- update setup scripts to load env vars from workflow output
- document workflow commands in README
- test workflow command handling and environment propagation

## Testing
- `just lint`
- `just test` *(fails: rbenv: version `3.2.1` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6863b1b1b1808329a052d66f658da3e7