### PR TITLE
Add workflow command expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,19 @@ The primary goal of this workflow is to:
     The `get-task` script will print the task description for the agent,
     along with instructions for accessing the downloaded internet resources
     and working with the git history.
+    It also supports a `--get-setup-env` option which prints only the
+    environment variable assignments gathered from `@agents-setup` lines.
+
+### Workflow Commands
+
+Task descriptions may include lines beginning with `/name`. When `get-task`
+is executed these lines are replaced with the output of a matching program in
+`.agents/workflows/name` (or the contents of `.agents/workflows/name.txt`).
+Lines starting with `@agents-setup` in either the task file or the workflow
+output are stripped from the final message and interpreted as environment
+variable assignments. These variables can be listed with `get-task --get-setup-env`
+and are automatically exported by the `*-setup` scripts before executing the
+project-specific setup steps.
 
 ## Supported Agent Systems
 

--- a/codex-setup
+++ b/codex-setup
@@ -48,6 +48,13 @@ EOF
 
 bash "$AGENTS_WORKFLOW_DIR/common-pre-setup"
 
+SETUP_ENV="$("$AGENTS_WORKFLOW_DIR/bin/get-task" --get-setup-env 2>/dev/null)"
+if [ -n "$SETUP_ENV" ]; then
+  while IFS= read -r line; do
+    export "$line"
+  done <<< "$SETUP_ENV"
+fi
+
 if [ -f .agents/codex-setup ]; then
   .agents/codex-setup
 fi

--- a/copilot-setup
+++ b/copilot-setup
@@ -4,6 +4,13 @@ AGENTS_WORKFLOW_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 bash "$AGENTS_WORKFLOW_DIR/common-pre-setup"
 
+SETUP_ENV="$("$AGENTS_WORKFLOW_DIR/bin/get-task" --get-setup-env 2>/dev/null)"
+if [ -n "$SETUP_ENV" ]; then
+  while IFS= read -r line; do
+    export "$line"
+  done <<< "$SETUP_ENV"
+fi
+
 if [ -f .agents/copilot-setup ]; then
   .agents/copilot-setup
 fi

--- a/goose-setup
+++ b/goose-setup
@@ -4,6 +4,13 @@ AGENTS_WORKFLOW_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 bash "$AGENTS_WORKFLOW_DIR/common-pre-setup"
 
+SETUP_ENV="$("$AGENTS_WORKFLOW_DIR/bin/get-task" --get-setup-env 2>/dev/null)"
+if [ -n "$SETUP_ENV" ]; then
+  while IFS= read -r line; do
+    export "$line"
+  done <<< "$SETUP_ENV"
+fi
+
 if [ -f .agents/goose-setup ]; then
   .agents/goose-setup
 fi

--- a/jules-setup
+++ b/jules-setup
@@ -4,6 +4,13 @@ AGENTS_WORKFLOW_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 bash "$AGENTS_WORKFLOW_DIR/common-pre-setup"
 
+SETUP_ENV="$("$AGENTS_WORKFLOW_DIR/bin/get-task" --get-setup-env 2>/dev/null)"
+if [ -n "$SETUP_ENV" ]; then
+  while IFS= read -r line; do
+    export "$line"
+  done <<< "$SETUP_ENV"
+fi
+
 if [ -f .agents/jules-setup ]; then
   .agents/jules-setup
 fi

--- a/open-hands-setup
+++ b/open-hands-setup
@@ -4,6 +4,13 @@ AGENTS_WORKFLOW_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 bash "$AGENTS_WORKFLOW_DIR/common-pre-setup"
 
+SETUP_ENV="$("$AGENTS_WORKFLOW_DIR/bin/get-task" --get-setup-env 2>/dev/null)"
+if [ -n "$SETUP_ENV" ]; then
+  while IFS= read -r line; do
+    export "$line"
+  done <<< "$SETUP_ENV"
+fi
+
 # We want to run
 if [ -f .agents/open-hands-setup ]; then
   .agents/open-hands-setup

--- a/test/test_workflows.rb
+++ b/test/test_workflows.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'tmpdir'
+require 'fileutils'
+require_relative 'test_helper'
+
+class WorkflowTest < Minitest::Test
+  include RepoTestHelper
+
+  def test_workflow_expansion_and_env
+    repo, remote = setup_repo(:git)
+    wf_dir = File.join(repo, '.agents', 'workflows')
+    FileUtils.mkdir_p(wf_dir)
+    script = File.join(wf_dir, 'hello')
+    File.write(script, "#!/bin/sh\necho hello\necho '@agents-setup FOO=bar'")
+    FileUtils.chmod(0o755, script)
+
+    status, = run_agent_task(repo, branch: 'feat', prompt: "/hello\n@agents-setup BAZ=1", push_to_remote: false)
+    assert_equal 0, status.exitstatus, 'agent-task should succeed'
+
+    VCSRepo.new(repo).checkout_branch('feat')
+    _, output = run_get_task(repo)
+    assert_includes output, 'hello', 'workflow output missing'
+    refute_includes output, '@agents-setup', 'setup directive should not appear'
+
+    cmd = [RepoTestHelper::GET_TASK, '--get-setup-env']
+    env_output = IO.popen(cmd, chdir: repo, &:read)
+    status2 = $CHILD_STATUS
+    assert_equal 0, status2.exitstatus, 'get-task --get-setup-env failed'
+    lines = env_output.split("\n")
+    assert_includes lines, 'FOO=bar', 'env from workflow missing'
+    assert_includes lines, 'BAZ=1', 'env from task missing'
+  ensure
+    FileUtils.remove_entry(repo) if repo && File.exist?(repo)
+    FileUtils.remove_entry(remote) if remote && File.exist?(remote)
+  end
+end


### PR DESCRIPTION
## Summary
- implement processing of workflow commands and env directives
- support `--get-setup-env` option in `get-task`
- export collected env vars from setup scripts
- document workflow usage
- test workflow processing

## Testing
- `just lint`
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_6863e76209e0832997503d7b3febfb4b