### PR TITLE
Apply heredocs for multiline test strings

### DIFF
--- a/.agents/tasks/2025/07/01-1348-workflows
+++ b/.agents/tasks/2025/07/01-1348-workflows
@@ -52,3 +52,6 @@ Let's improve the test cases for the workflows feature:
 2) I'd like some of tests to involve more then one workflow commands.
 3) I'd like some of the task descriptions to be longer, where the workflow command appears as a first line, as a last line (with or without a trailing whitespace), in the middle of the text, with trailing whitespace on the line, etc.
 4) I'd like to see some workflow commands accepting parameters. Make sure some of the parameters are strings that contain spaces.
+
+--- FOLLOW UP TASK ---
+In the tests folder, use indented heredoc strings instead of single-line strings with "\n" characters in order to make the code easier to read.

--- a/test/test_start_task.rb
+++ b/test/test_start_task.rb
@@ -138,7 +138,9 @@ module StartTaskCases # rubocop:disable Metrics/ModuleLength
       repo, remote = setup_repo(self.class::VCS_TYPE)
       dir = Dir.mktmpdir('pf')
       file = File.join(dir, 'msg.txt')
-      File.write(file, "file text\n")
+      File.write(file, <<~TEXT)
+        file text
+      TEXT
       push_flag = self.class::VCS_TYPE != :fossil
       status, = run_agent_task(repo, branch: 'pf1', prompt_file: file, push_to_remote: push_flag, tool: bin)
       # agent-task should succeed when --prompt-file is provided

--- a/test/test_vcs_repo_methods.rb
+++ b/test/test_vcs_repo_methods.rb
@@ -51,7 +51,10 @@ class TestVCSRepoMethods < Minitest::Test
     vcs_repo = VCSRepo.new(repo)
 
     # Create a commit with a specific message
-    test_message = "Test commit message\nWith multiple lines"
+    test_message = <<~MSG.chomp
+      Test commit message
+      With multiple lines
+    MSG
     test_file = File.join(repo, 'test.txt')
     File.write(test_file, 'test content')
 


### PR DESCRIPTION
## Summary
- replace newline escape sequences with indented heredocs in tests
- keep lint clean and ensure tests pass

## Testing
- `just lint`
- `just test`

------
https://chatgpt.com/codex/tasks/task_e_6865517169408329b0f3b20b33176a54