### PR TITLE
fix: add lib path to Nix wrapper

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -19,3 +19,8 @@
 - Set EXTRAS="nix,direnv,cachix" with flexible delimiter parsing
 - Uses Rake tasks in Rakefile.extras for dependency resolution
 
+## Nix Packaging
+- `nix run` uses a wrapper that now adds the project's `lib` directory to the Ruby load
+  path. Executables should `require` files via the load path rather than relative paths
+  so they work when copied into the Nix store.
+

--- a/bin/agent-task
+++ b/bin/agent-task
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative '../lib/agent_task/cli'
+lib_dir = File.expand_path('../lib', __dir__)
+$LOAD_PATH.unshift(lib_dir) unless $LOAD_PATH.include?(lib_dir)
+require 'agent_task/cli'
 
 if ARGV.first == 'setup'
   ARGV.shift

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
             pkgs.gemini-cli
             codex.packages.${system}.codex-rs
           ]}:$PATH
-          exec ruby ${./bin/agent-task} "$@"
+          exec ruby -I ${./lib} ${./bin/agent-task} "$@"
         '';
         get-task = pkgs.writeShellScriptBin "get-task" ''
           exec ${pkgs.ruby}/bin/ruby ${./bin/get-task} "$@"


### PR DESCRIPTION
This fixes the following error:

When I run `nix run .` I get an error /nix/store/dlh6zvwghhifg5ifywaa6y00ajgvs54d-agent-task:4:in `require_relative': cannot load such file -- /nix/lib/agent_task/cli (LoadError)
	from /nix/store/dlh6zvwghhifg5ifywaa6y00ajgvs54d-agent-task:4:in `<main>'

